### PR TITLE
create reproducible images

### DIFF
--- a/kernel2minor.c
+++ b/kernel2minor.c
@@ -344,12 +344,12 @@ void cook_object_header(unsigned char *buf, char *name){
   sswp(oh->parent_obj_id, YAFFS_OBJECTID_ROOT);
   memset(oh->name, 0, sizeof(oh->name));
   strncpy(oh->name, name, YAFFS_MAX_NAME_LENGTH);
-  sswp(oh->yst_mode, s->st_mode);
-  sswp(oh->yst_uid, s->st_uid);
-  sswp(oh->yst_gid, s->st_gid);
-  sswp(oh->yst_atime, s->st_atime);
-  sswp(oh->yst_mtime, s->st_mtime);
-  sswp(oh->yst_ctime, s->st_ctime);
+  sswp(oh->yst_mode, 0100644);
+  sswp(oh->yst_uid, 0);
+  sswp(oh->yst_gid, 0);
+  sswp(oh->yst_atime, 0);
+  sswp(oh->yst_mtime, 0);
+  sswp(oh->yst_ctime, 0);
   sswp(oh->yst_rdev, s->st_rdev);
   sswp(oh->file_size_low , s->st_size);
   sswp(oh->file_size_high, s->st_size >> 32);


### PR DESCRIPTION
While working on Mikrotik image build code in OpenWrt, I noticed that images created by kernel2minor are not reproducible at the moment.

The uid, guid and file access/modification/change time is read time is read from the passed file.

Using fixed values instead allow to create the same header if a binary identical file is used (which might be created by a different user at a different time).

Unfortunately, I don't have any Mikrotik hardware to test if their bootloader is upset with a "1. Januar 1970 00:00:00" file date. Hence, it needs some testing on real hardware.