### PR TITLE
check length of filenames for kernel and result file

### DIFF
--- a/kernel2minor.c
+++ b/kernel2minor.c
@@ -590,12 +590,25 @@ int calc_needed_vars(void){
 int main(int argc, char *argv[]){
   int k = 0;
   int r = 0;
+  int res = 0;
   int ch; //для парсинга параметров
   //загружаем параметры командной строки
   while( (ch = getopt(argc, argv, "k:r:s:i:p:cevh")) != -1){
     switch(ch){
-      case 'k': snprintf(kernel_file, sizeof(kernel_file) - 1, "%s", optarg); break;
-      case 'r': snprintf(res_file, sizeof(res_file) - 1, "%s", optarg); break;
+      case 'k':
+        res = snprintf(kernel_file, sizeof(kernel_file) - 1, "%s", optarg);
+        if(res >= sizeof(kernel_file) - 1){
+          fprintf(stderr, "kernel file name is longer than compile time limit of %li chars.\n", sizeof(kernel_file) - 1);
+          exit(1);
+        }
+        break;
+      case 'r':
+        res = snprintf(res_file, sizeof(res_file) - 1, "%s", optarg);
+        if(res >= sizeof(res_file) - 1){
+          fprintf(stderr, "result file name is longer than compile time limit of %li chars.\n", sizeof(res_file) - 1);
+          exit(1);
+        }
+        break;
       case 'c': use_ecc = 1; break;
       case 'e': to_big_endian = 1; break;
       case 's': chunk_size = atoi(optarg); break;


### PR DESCRIPTION
During OpenWrt CI-build I had some "file not found" errors causing build-aborts. 

> kernel2minor -k /home/runner/work/freifunk-berlin-firmware/freifunk-berlin-firmware/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_mikrotik/tmp/freifunk-berlin-sam0815-next-nightly-02fd7ea-ath79-mikrotik-mikrotik_routerboard-922uags-5hpacd-squashfs-sysupgrade.bin -r /home/runner/work/freifunk-berlin-firmware/freifunk-berlin-firmware/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_mikrotik/tmp/freifunk-berlin-sam0815-next-nightly-02fd7ea-ath79-mikrotik-mikrotik_routerboard-922uags-5hpacd-squashfs-sysupgrade.bin.new -s 2048 -e -c
Successfully writed 15 blocks and 2027520 bytes
Each block contain 64 chanks + 0 bytes tail hole.
Each chunk(2112 bytes) consists: data part(2048 bytes) + oob part(64 bytes).
mv /home/runner/work/freifunk-berlin-firmware/freifunk-berlin-firmware/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_mikrotik/tmp/freifunk-berlin-sam0815-next-nightly-02fd7ea-ath79-mikrotik-mikrotik_routerboard-922uags-5hpacd-squashfs-sysupgrade.bin.new /home/runner/work/freifunk-berlin-firmware/freifunk-berlin-firmware/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_mikrotik/tmp/freifunk-berlin-sam0815-next-nightly-02fd7ea-ath79-mikrotik-mikrotik_routerboard-922uags-5hpacd-squashfs-sysupgrade.bin
mv: cannot stat '/home/runner/work/freifunk-berlin-firmware/freifunk-berlin-firmware/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_mikrotik/tmp/freifunk-berlin-sam0815-next-nightly-02fd7ea-ath79-mikrotik-mikrotik_routerboard-922uags-5hpacd-squashfs-sysupgrade.bin.new': No such file or directory

It turned out to be caused by silently creating the result-file as ```/home/runner/work/freifunk-berlin-firmware/freifunk-berlin-firmware/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_mikrotik/tmp/freifunk-berlin-sam0815-next-nightly-02fd7ea-ath79-mikrotik-mikrotik_routerboard-922uags-5hpacd-squashfs-sysupgrade.bin.n``, as the long filename doesn't fit into the "res_file" variable. 

This PR adds a check that if the argument is larger than the compile-time limit an error message is given and the program stops.